### PR TITLE
Nodecraft fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you really want to contribute to this, sure, why not, go ahead.
 - [PaperMC](https://papermc.io/) for a fantastic third-party server. [PaperMC GitHub](https://github.com/PaperMC)
 - [VSCodium](https://vscodium.com/) because @#$% Microsoft.
 - [MCVersions.net](https://mcversions.net/) for providing download links for Server Jar files
-- [MCUUID](https://mcuuid.net/) for providing information on player UUID (assists in player operations before they have ever joined)
+- [PlayerDB](https://playerdb.co/) for providing information on player UUID (assists in player operations before they have ever joined)
 - [Official Minecraft Wiki - Gamepedia](https://minecraft.gamepedia.com/Server.properties)
 - [Daniel Ennis](https://aikar.co/author/daniel-ennis-aikar/) for providing [invaluable information](https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/) on JVM garbage collection to improve running Minecraft servers
 

--- a/app.js
+++ b/app.js
@@ -32,10 +32,6 @@ const Sass = require('node-sass');
 // scraping websites
 const fetch = require('node-fetch');
 
-/// cheerio
-// Makes it easier to parse HTML for scraping Jar download links
-const cheerio = require('cheerio');
-
 /// moment
 // For tracking usage and other stuff
 const moment = require('moment');
@@ -93,7 +89,7 @@ const PATHS = {
 // TODO: Add support for Bedrock edition, if it ever leaves Alpha stages.
 //       Current Bedrock link is also not Direct Download.
 const DOWNLOAD_LINKS = {
-	vanilla: 'https://mcversions.net/download/',
+	vanilla: 'https://mcversions.net/mcversions.json',
 	paper: {
 		1.15: 'https://papermc.io/ci/job/Paper-1.15/lastSuccessfulBuild/artifact/paperclip.jar',
 		1.14: 'https://papermc.io/ci/job/Paper-1.14/lastSuccessfulBuild/artifact/paperclip.jar',
@@ -406,15 +402,13 @@ function renderSass(res, next) {
 	Sass.render({ file: PATHS.sass, outputStyle: 'compressed' }, (err, result) => err ? next(err) : res.type('css').send(result.css));
 }
 
-// Scrape the download URL for Vanilla Minecraft from mcversions.net
+// Scrape the download URL for Vanilla Minecraft
+// from mcversions.net/mcversions.json
 function getVanillaUrl(version) {
 	return new Promise((resolve, reject) => {
-		fetch(DOWNLOAD_LINKS.vanilla + version)
-			.then((response) => response.text())
-			// The site doesn't have DOM ID's which makes parsing the correct
-			// link difficult, sketchy string splits it is! If the site ever
-			// changes its layout, this will most likely need to be fixed.
-			.then((dom) => cheerio.load(dom)('.downloads').html().split('href="')[1].split('" download')[0])
+		fetch(DOWNLOAD_LINKS.vanilla)
+			.then((response) => response.json())
+			.then((json) => json.stable[version].server)
 			.then((url) => resolve(url))
 			.catch((err) => reject(err));
 	});

--- a/app.js
+++ b/app.js
@@ -106,7 +106,7 @@ const DOWNLOAD_LINKS = {
 /// PLAYER_UUID_LINK
 // Link for where to grab info on Minecraft Player UUID's. These are helpful
 // for opping / whitelisting players before they have joined.
-const PLAYER_UUID_LINK = 'https://mcuuid.net/?q=';
+const PLAYER_UUID_LINK = 'https://playerdb.co/api/player/minecraft/';
 
 /// MEMORY_SPLIT
 // Amount of dedicated RAM for a Jar file is total free system memory divided
@@ -711,9 +711,12 @@ function getPlayerUuid(name) {
 	log.info(`Attempting to grab UUID for Player '${name}`);
 	return new Promise((resolve, reject) => {
 		fetch(PLAYER_UUID_LINK + name)
-			.then((response) => response.text())
-			.then((dom) => cheerio.load(dom)('#results_id').val())
-			.then((uuid) => resolve(uuid))
+			.then((response) => response.json())
+			.then((json) => {
+				if (json.error) throw Error(json.message);
+				else return json.data.player.id;
+			})
+			.then((puuid) => resolve(puuid))
 			.catch((err) => reject(err));
 	});
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/tycrek/McServerman#readme",
   "dependencies": {
-    "cheerio": "^1.0.0-rc.3",
     "express": "^4.17.1",
     "fs-extra": "^9.0.0",
     "gamedig": "^2.0.20",


### PR DESCRIPTION
Added suggestions from Issue #2 from @Cherry:

Player UUID's now come from [PlayerDB](https://playerdb.co/) and their fantastic **free** API.

Server Jar download links still come from [MCVersions.net](https://mcversions.net/) but utilize their JSON file instead of parsing HTML.

Removed Cheerio dependency since we no longer have to parse HTML.